### PR TITLE
Hotfix/1.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
         "react-dom": "^16.4.1",
         "react-redux": "^5.0.7",
         "redux": "^4.0.0",
+        "rwc-feersum-client": "^1.2.0",
         "recompose": "^0.27.1"
     },
     "devDependencies": {
         "prop-types": "^15.6.1",
-        "rwc-feersum-client": "^1.2.0",
         "@prk/eslint-config": "^0.0.9",
         "@prk/prettier-config": "^0.0.2",
         "nodemon": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prk/react-web-chat",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "description": "react-web-chat React component",
     "main": "lib/index.js",
     "module": "es/index.js",
@@ -20,34 +20,30 @@
         "document:watch": "nodemon --watch src --exec './node_modules/.bin/esdoc'"
     },
     "dependencies": {
-        "@prk/eslint-config": "^0.0.9",
-        "@prk/prettier-config": "^0.0.2",
         "lodash": "^4.17.10",
-        "nodemon": "^1.17.5",
         "react-slick": "^0.23.1",
         "react-transition-group": "^2.3.1",
         "redux-thunk": "^2.3.0",
-        "rwc-feersum-client": "^1.2.0",
         "slick-carousel": "^1.8.1",
-        "smooth-scroll-to-js": "^0.0.2"
-    },
-    "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
+        "smooth-scroll-to-js": "^0.0.2",
+        "react": "^16.4.1",
+        "react-dom": "^16.4.1",
+        "react-redux": "^5.0.7",
+        "redux": "^4.0.0",
+        "recompose": "^0.27.1"
     },
     "devDependencies": {
+        "prop-types": "^15.6.1",
+        "rwc-feersum-client": "^1.2.0",
+        "@prk/eslint-config": "^0.0.9",
+        "@prk/prettier-config": "^0.0.2",
+        "nodemon": "^1.17.5",
         "esdoc": "^1.0.4",
         "esdoc-ecmascript-proposal-plugin": "^1.0.0",
         "esdoc-jsx-plugin": "^1.0.0",
         "esdoc-standard-plugin": "^1.0.0",
         "nwb": "^0.21.5",
-        "nwb-sass": "^0.8.1",
-        "prop-types": "^15.6.1",
-        "react": "^16.4.1",
-        "react-dom": "^16.4.1",
-        "react-redux": "^5.0.7",
-        "recompose": "^0.27.1",
-        "redux": "^4.0.0"
+        "nwb-sass": "^0.8.1"
     },
     "license": "MIT",
     "repository": "git@github.com:praekelt/react-web-chat.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prk/react-web-chat",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "description": "react-web-chat React component",
     "main": "lib/index.js",
     "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import { createStoreWithState } from './store';
 import { merge } from 'lodash';
 
 import { Provider } from 'react-redux';
-import smoothscroll from 'smoothscroll-polyfill';
 
 import ChatContainer from './components/ChatContainer';
 
@@ -15,7 +14,6 @@ import NetworkManager from './utils/network';
 import defaultTheme from './themes/default';
 import defaultConfig from './config';
 
-smoothscroll.polyfill();
 /**
  * The main react component for React Web Chat
  * @param {Object} params - An object containing configuration parameters


### PR DESCRIPTION
# Background
In testing locally it somehow slipped past that the reference to `smoothscroll-polyfill` still existed and resulted in things breaking. Weird, because it was _actually working_ when I was testing earlier. It's possible that was due to the fact that I had linked the module locally, and it still had a reference to that polyfill dependency.

In any case, I resolved that.

# What was done
All references to the smooth scroll polyfill have been removed in the code.

Additionally, I've rejiggered the way we were handling dependencies, as some dev dependencies were being downloaded unnecessarily by the user, and some actual dependencies were being treated as dev dependencies. This should make using this smoother in future.