### PR TITLE
Improve MessageList rendering performance

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -28,7 +28,7 @@ class Demo extends Component {
                         variance: 500
                     }}
                     network={{
-                        channel_id: '8ca2deee-433d-453f-a6b1-8edce1ce4f8c'
+                        channel_id: '3998e8a9-b329-4de9-a03c-040cc0348e42'
                     }}
                     avatar="http://i.pravatar.cc/300"
                 />

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -28,7 +28,7 @@ class Demo extends Component {
                         variance: 500
                     }}
                     network={{
-                        channel_id: '3998e8a9-b329-4de9-a03c-040cc0348e42'
+                        channel_id: '8ca2deee-433d-453f-a6b1-8edce1ce4f8c'
                     }}
                     avatar="http://i.pravatar.cc/300"
                 />

--- a/src/components/MessageList/MessageListItem.js
+++ b/src/components/MessageList/MessageListItem.js
@@ -1,0 +1,70 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import AvatarContainer from '../AvatarContainer';
+import MessageContainer from '../MessageContainer';
+import Message from '../Message';
+
+class MessageListItem extends PureComponent {
+    render() {
+        const {
+            itemRef,
+            message,
+            prevMessageOrigin,
+            submitHandler,
+            theme
+        } = this.props;
+        return (
+            <li
+                className={`MessagesList-item${
+                    message.origin === 'local' ? ' is-local' : ''
+                }`}
+                ref={itemRef}
+            >
+                {message.origin === 'remote' && prevMessageOrigin && (
+                    <AvatarContainer AvatarComponent={theme.AvatarComponent} />
+                )}
+                <div className="MessagesList-messageItem">
+                    <MessageContainer key="text" {...message}>
+                        {message.origin === 'remote' ? (
+                            message.pages.map((page, i) => (
+                                <Message
+                                    key={i}
+                                    page={page}
+                                    isLocal={message.origin === 'local'}
+                                    {...theme}
+                                    submitHandler={submitHandler}
+                                />
+                            ))
+                        ) : (
+                            <Message
+                                page={{ text: message.text }}
+                                isLocal={true}
+                                {...theme}
+                            />
+                        )}
+                    </MessageContainer>{' '}
+                    {message.buttons && message.buttonStyle === 'default' && (
+                        <MessageContainer key="buttons" {...message}>
+                            {message.buttons.map((button, i) => (
+                                <theme.ButtonComponent
+                                    key={i}
+                                    text={button.text}
+                                    phone={button.phone}
+                                    url={button.url}
+                                    onClick={() =>
+                                        submitHandler({
+                                            postback: button.postback,
+                                            text: button.text
+                                        })
+                                    }
+                                />
+                            ))}
+                        </MessageContainer>
+                    )}
+                </div>
+            </li>
+        );
+    }
+}
+
+export default MessageListItem;

--- a/src/components/MessageList/index.js
+++ b/src/components/MessageList/index.js
@@ -3,10 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import smoothScrollTo from 'smooth-scroll-to-js';
 
-// import AvatarContainer from '../AvatarContainer';
 import MessageContainer from '../MessageContainer';
-// import Message from '../Message';
-
 import * as messageActions from '../../actions/messages';
 import MessageListItem from './MessageListItem';
 

--- a/src/components/MessageList/index.js
+++ b/src/components/MessageList/index.js
@@ -3,11 +3,12 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import smoothScrollTo from 'smooth-scroll-to-js';
 
-import AvatarContainer from '../AvatarContainer';
+// import AvatarContainer from '../AvatarContainer';
 import MessageContainer from '../MessageContainer';
-import Message from '../Message';
+// import Message from '../Message';
 
 import * as messageActions from '../../actions/messages';
+import MessageListItem from './MessageListItem';
 
 const mapStateToProps = ({ messages, config }) => ({
     messages: messages.messages,
@@ -32,14 +33,18 @@ class MessageList extends React.Component {
         this.state = {
             offset: 0
         };
+
+        this.lastMsgRef = React.createRef();
+        this.containerRef = React.createRef();
     }
 
     componentDidUpdate() {
-        this._last &&
+        this.lastMsgRef.current &&
+            this.containerRef.current &&
             smoothScrollTo({
-                to: this._last,
-                container: this._last.parentElement.parentElement,
-                duration: 12
+                to: this.lastMsgRef.current,
+                container: this.containerRef.current,
+                duration: 1
             });
     }
 
@@ -52,94 +57,34 @@ class MessageList extends React.Component {
             config
         } = this.props;
         return (
-            <div
-                className="ChatContainer-content"
-                ref={ref => (this._ref = ref)}
-            >
+            <div className="ChatContainer-content" ref={this.containerRef}>
                 <ul className="MessagesList">
                     {messages.map((message, i) => (
-                        <li
-                            className={`MessagesList-item${
-                                message.origin === 'local' ? ' is-local' : ''
-                            }`}
-                            key={i}
-                            ref={ref => {
-                                if (i === messages.length - 1) {
-                                    this._last = ref;
-                                }
-                            }}
-                        >
-                            {message.origin === 'remote' &&
-                                (messages[i - 1]
+                        <MessageListItem
+                            key={message.timeAdded}
+                            {...{
+                                message,
+                                prevMessageOrigin: messages[i - 1]
                                     ? messages[i - 1].origin !== 'remote'
-                                    : true) && (
-                                    <AvatarContainer
-                                        AvatarComponent={theme.AvatarComponent}
-                                    />
-                                )}
-                            <div className="MessagesList-messageItem">
-                                <MessageContainer key="text" {...message}>
-                                    {message.origin === 'remote' ? (
-                                        message.pages.map((page, i) => (
-                                            <Message
-                                                key={i}
-                                                page={page}
-                                                isLocal={
-                                                    message.origin === 'local'
-                                                }
-                                                {...theme}
-                                                submitHandler={submitHandler}
-                                            />
-                                        ))
-                                    ) : (
-                                        <Message
-                                            key={i}
-                                            page={{ text: message.text }}
-                                            isLocal={true}
-                                            {...theme}
-                                        />
-                                    )}
-                                </MessageContainer>{' '}
-                                {message.buttons &&
-                                    message.buttonStyle === 'default' && (
-                                        <MessageContainer
-                                            key="buttons"
-                                            {...message}
-                                        >
-                                            {message.buttons.map(
-                                                (button, i) => (
-                                                    <theme.ButtonComponent
-                                                        key={i}
-                                                        text={button.text}
-                                                        phone={button.phone}
-                                                        url={button.url}
-                                                        onClick={() =>
-                                                            submitHandler({
-                                                                postback:
-                                                                    button.postback,
-                                                                text:
-                                                                    button.text
-                                                            })
-                                                        }
-                                                    />
-                                                )
-                                            )}
-                                        </MessageContainer>
-                                    )}
-                            </div>
-                            {messageQueue.length &&
-                            i === messages.length - 1 &&
-                            config.typingStatus.active
-                                ? [
-                                      <MessageContainer key="typing">
-                                          <theme.TypingIndicatorComponent
-                                              {...config.TypingIndicator}
-                                          />
-                                      </MessageContainer>
-                                  ]
-                                : null}
-                        </li>
+                                    : true,
+
+                                submitHandler,
+                                theme,
+                                ...(messages.length - 1 === i && {
+                                    itemRef: this.lastMsgRef
+                                })
+                            }}
+                        />
                     ))}
+                    {messageQueue.length && config.typingStatus.active ? (
+                        <li>
+                            <MessageContainer key="typing">
+                                <theme.TypingIndicatorComponent
+                                    {...config.TypingIndicator}
+                                />
+                            </MessageContainer>
+                        </li>
+                    ) : null}
                 </ul>
             </div>
         );


### PR DESCRIPTION
# Background
While doing QA on MTN Play it was noticed that the site was rather janky on low-end devices. On further investigation, we became aware of the fact that the message list was re-rendering all the messages on each render.

# What was done
Extracted MessageListItem from MessageList as a PureComponent.
cleanup its logic a bit. reduce animation speed of smoothScrolltoJs to 1 (AKA instant scroll) the message animations are sufficient.

# Future improvements
investigate virtualisation of lists using something like react-window.
